### PR TITLE
Update schema.example.prisma

### DIFF
--- a/prisma/schema.example.prisma
+++ b/prisma/schema.example.prisma
@@ -14,8 +14,7 @@ generator client {
 datasource db {
     provider          = "postgresql"
     url               = env("POSTGRES_PRISMA_URL") // uses connection pooling
-    directUrl         = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
-    shadowDatabaseUrl = env("POSTGRES_URL_NON_POOLING") // used for migrations
+    directUrl         = env("POSTGRES_URL_NON_POOLING") // used for migrations
 }
 
 model User {


### PR DESCRIPTION
`shadowDatabaseUrl` is no longer required for Vercel Postgres and may cause issues when set to the same value as `directUrl`.